### PR TITLE
Add interop package

### DIFF
--- a/Interop.UIAutomationCore.nuspec
+++ b/Interop.UIAutomationCore.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>TestStack.Interop.UIAutomationCore</id>
+    <version>$version$</version>
+    <title>TestStack.Interop.UIAutomationCore</title>
+    <summary>UIAutomationCore exposes UIAutomationCore functionality for use by managed code.</summary>
+    <description>This exposes UIAutomation functionality that is defined in UIAutomationCore.idl</description>
+    <authors>Ivan Danilov</authors>
+    <owners>Ivan Danilov</owners>
+    <projectUrl>https://github.com/TestStack/uia-custom-pattern-managed</projectUrl>
+    <license type="expression">MIT</license>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>UIAutomation Testing UIA WPF Win32 Automation</tags>
+  </metadata>
+  <files>
+    <file src=".\UIACoreInterop\Build\Interop.UIAutomationCore.dll" target="lib\net40" />
+  </files>
+</package>

--- a/Interop.UIAutomationCore.nuspec
+++ b/Interop.UIAutomationCore.nuspec
@@ -4,7 +4,7 @@
     <id>TestStack.Interop.UIAutomationCore</id>
     <version>$version$</version>
     <title>TestStack.Interop.UIAutomationCore</title>
-    <summary>UIAutomationCore exposes UIAutomationCore functionality for use by managed code.</summary>
+    <summary>Interop.UIAutomationCore.dll exposes UIAutomationCore functionality for use by managed code.</summary>
     <description>This exposes UIAutomation functionality that is defined in UIAutomationCore.idl</description>
     <authors>Ivan Danilov</authors>
     <owners>Ivan Danilov</owners>

--- a/build-and-publish.bat
+++ b/build-and-publish.bat
@@ -23,6 +23,10 @@ if errorlevel 1 goto somethingbad
 GitLink . -u https://github.com/TestStack/uia-custom-pattern-managed -c Release -include ManagedUiaCustomizationCore
 if errorlevel 1 goto somethingbad
 
+echo nuget pack Interop.UIAutomationCore.nuspec -version "%GitVersion_NuGetVersion%"
+nuget pack Interop.UIAutomationCore.nuspec -version "%GitVersion_NuGetVersion%" -verbosity detailed -basepath .
+if errorlevel 1 goto somethingbad
+
 echo nuget pack UiaCustomPattersManaged.nuspec -version "%GitVersion_NuGetVersion%"
 nuget pack UiaCustomPattersManaged.nuspec -version "%GitVersion_NuGetVersion%" -verbosity detailed -basepath .
 if errorlevel 1 goto somethingbad
@@ -35,7 +39,7 @@ if errorlevel 1 goto somethingbad
 
 echo Finished successfully
 echo(---------------------
-echo Remember to publish created nupkg file and update Changes section in Readme.md
+echo Remember to publish created nupkg files and update Changes section in Readme.md
 goto end
 
 :somethingbad


### PR DESCRIPTION
@ivan-danilov, this adds a .nuspec file to ship Interop.UIAutomationCore.dll as a standalone MIT-licensed package, without the additional assemblies from the project. We tried consuming the existing package, but the long tail of dependencies was essentially a blocker for us ☹️ 

Would you be willing to merge this PR and publish a standalone package of just the interop assembly? That would allow us to integrate it seamlessly into our build system with all of the appropriate third party attributions intact. Thanks!